### PR TITLE
DEVOPS-9392 Add 5000 port mapping

### DIFF
--- a/.ebextensions/01-commands.config
+++ b/.ebextensions/01-commands.config
@@ -1,0 +1,4 @@
+commands:
+    00001_add_port_mapping:
+        cwd: /tmp
+        command: 'sed -i "s/docker run -d/docker run -p 5000:5000 -d/" /opt/elasticbeanstalk/hooks/appdeploy/enact/00run.sh'


### PR DESCRIPTION
To allow connection of jnlp slaves it is required to open 5000 port